### PR TITLE
Add CocoaPods podspec for a future 3.0.0 release.

### DIFF
--- a/Reachability.podspec
+++ b/Reachability.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = 'Reachability'
+  s.version      = '3.0.0'
+  s.license      = 'BSD'
+  s.platform     = :ios
+  s.homepage     = 'https://github.com/tonymillion/Reachability'
+  s.authors      = { 'Tony Million' => 'tonymillion@gmail.com' }
+  s.summary      = 'ARC and GCD Compatible Reachability Class for iOS. Drop in replacement for Apple Reachability.'
+  s.source       = { :git => 'https://github.com/tonymillion/Reachability.git', :tag => '3.0.0' }
+  s.source_files = 'Reachability.{h,m}'
+  s.framework    = 'SystemConfiguration'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Like discussed on twitter, I think it would be great if your modern version can become the de facto version of ‘Reachability’.

Currently we have a [‘2.0.5’](https://github.com/CocoaPods/unmaintained-pod-Reachability) version of [the spec](https://github.com/CocoaPods/Specs/blob/master/Reachability/2.0.5/Reachability.podspec), which is basically the latest version of the code of what’s vendored in [ASIHTTPRequest](https://github.com/pokeb/asi-http-request/tree/4282568eec0b487a98e312ce49b523350ffa4a6b/External/Reachability).

(I created this release, because ASIHTTPRequest is no longer maintained, but the unreleased code in the repo contains a few compilation related fixes.)

In any case, once you feel it’s good enough for a release (which can be right now, that’s totally up to you of course), you should create a tag with the version number that you are releasing and add a copy of the podspec file to the [spec repo](https://github.com/CocoaPods/Specs/tree/master/Reachability) to make it available to the masses. (I’ll give you push access to the spec repo for future releases after this first spec has gone in.)

Regarding version number, I think it’s wise to use something higher than 2.x, i.e. 3.x, to illustrate the fact that the code is different.

Finally, like the one from Apple and ASIHTTPRequest, yours only compiles on iOS, but there are people [using it on OS X](http://stackoverflow.com/questions/2995822/check-internet-connection-in-cocoa-application). Is this something you might consider supporting? If so, then the [platform restraint](https://github.com/alloy/Reachability/blob/master/Reachability.podspec#L5) should be removed to make it available to OS X projects as well.

Thanks for your time!
