### PR TITLE
Fix NEEDS_DISPATCH_RETAIN_RELEASE checks

### DIFF
--- a/Reachability.m
+++ b/Reachability.m
@@ -221,7 +221,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
         //clear out the dispatch queue
         if(self.reachabilitySerialQueue)
         {
-#ifdef NEEDS_DISPATCH_RETAIN_RELEASE
+#if NEEDS_DISPATCH_RETAIN_RELEASE
             dispatch_release(self.reachabilitySerialQueue);
 #endif
             self.reachabilitySerialQueue = nil;
@@ -247,7 +247,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
         // then clear out the dispatch queue
         if(self.reachabilitySerialQueue)
         {
-#ifdef NEEDS_DISPATCH_RETAIN_RELEASE
+#if NEEDS_DISPATCH_RETAIN_RELEASE
             dispatch_release(self.reachabilitySerialQueue);
 #endif
             self.reachabilitySerialQueue = nil;
@@ -271,7 +271,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
     
     if(self.reachabilitySerialQueue)
     {
-#ifdef NEEDS_DISPATCH_RETAIN_RELEASE
+#if NEEDS_DISPATCH_RETAIN_RELEASE
         dispatch_release(self.reachabilitySerialQueue);
 #endif
         self.reachabilitySerialQueue = nil;


### PR DESCRIPTION
It was using `ifdef` instead of `if`. It is defined either way, so `if` is the correct macro. This fixed building for iOS 6 and 10.8.
