### PR TITLE
Eliminate warning when project is not using ARC

### DIFF
--- a/Reachability.m
+++ b/Reachability.m
@@ -71,7 +71,11 @@ static NSString *reachabilityFlags(SCNetworkReachabilityFlags flags)
 static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void* info) 
 {
 #pragma unused (target)
+#if __has_feature(obj_arc)
     Reachability *reachability = ((__bridge Reachability*)info);
+#else
+    Reachability *reachability = ((Reachability*)info);
+#endif
     
     // we probably dont need an autoreleasepool here as GCD docs state each queue has its own autorelease pool
     // but what the heck eh?
@@ -212,8 +216,11 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
         return NO;
     }
     
-    
+#if __has_feature(obj_arc)
     context.info = (__bridge void *)self;
+#else
+    context.info = (void *)self;
+#endif
     
     if (!SCNetworkReachabilitySetCallback(self.reachabilityRef, TMReachabilityCallback, &context)) 
     {


### PR DESCRIPTION
Added a simple check of feature obj_arc to determine if we need to use a __bridge cast, which causes a warning message when the project itself is not using ARC.

Some reference:
- https://github.com/rs/SDWebImage/issues/155
- http://stackoverflow.com/questions/12509463/bridge-casts-have-no-effect-when-not-using-arc
