### PR TITLE
Add a debug description to Reachability objects

### DIFF
--- a/Reachability.m
+++ b/Reachability.m
@@ -509,4 +509,13 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
     });
 }
 
+#pragma mark - Debug Description
+
+- (NSString *) description;
+{
+    NSString *description = [NSString stringWithFormat:@"<%@: %#x; isReachable: %s; current reachability flags: %@>",
+                             NSStringFromClass([self class]), (unsigned int) self, (self.isReachable ? "YES" : "NO" ), self.currentReachabilityFlags];
+    return description;
+}
+
 @end


### PR DESCRIPTION
This prints more info about the object when running `print-object` in the debugger on a Reachability object or when an object is logged to console. I deliberately didn't include every single property about the object; I found these fields to be a good amount of "summary" info at a glance, and one can always query more specific properties about the object if desired.

(Note: there's a new API on `NSObject` for `-debugDescription`, starting with iOS 6.0 and OS X 10.8, but I didn't want to include nine kinds of `ifdef`s for a small "this would be nice" pull request.)
