### PR TITLE
Fixed compiler warning "Semicolon before method body is ignored"

### DIFF
--- a/Reachability.m
+++ b/Reachability.m
@@ -517,7 +517,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
 #pragma mark - Debug Description
 
-- (NSString *) description;
+- (NSString *) description
 {
     NSString *description = [NSString stringWithFormat:@"<%@: %#x>",
                              NSStringFromClass([self class]), (unsigned int) self];


### PR DESCRIPTION
Fixed Xcode compiler warning "Semicolon before method body is ignored"
in Reachability.m. description method had a semicolon after the method
definition.
