### PR TITLE
Allow subclasses to manipulate reachabilityFlags

### DIFF
--- a/Reachability.m
+++ b/Reachability.m
@@ -335,9 +335,9 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
 -(BOOL)isReachable
 {
-    SCNetworkReachabilityFlags flags;  
+    SCNetworkReachabilityFlags flags = self.reachabilityFlags;
     
-    if(!SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
+    if(!flags)
         return NO;
     
     return [self isReachableWithFlags:flags];
@@ -347,9 +347,9 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 {
 #if	TARGET_OS_IPHONE
 
-    SCNetworkReachabilityFlags flags = 0;
+    SCNetworkReachabilityFlags flags = self.reachabilityFlags;
     
-    if(SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) 
+    if(flags) 
     {
         // Check we're REACHABLE
         if(flags & kSCNetworkReachabilityFlagsReachable)
@@ -368,9 +368,9 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
 -(BOOL)isReachableViaWiFi 
 {
-    SCNetworkReachabilityFlags flags = 0;
+    SCNetworkReachabilityFlags flags = self.reachabilityFlags;
     
-    if(SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) 
+    if(flags)
     {
         // Check we're reachable
         if((flags & kSCNetworkReachabilityFlagsReachable))
@@ -399,9 +399,9 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
 -(BOOL)connectionRequired
 {
-    SCNetworkReachabilityFlags flags;
+    SCNetworkReachabilityFlags flags = self.reachabilityFlags;
 	
-	if(SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) 
+	if(flags) 
     {
 		return (flags & kSCNetworkReachabilityFlagsConnectionRequired);
 	}
@@ -412,9 +412,9 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 // Dynamic, on demand connection?
 -(BOOL)isConnectionOnDemand
 {
-	SCNetworkReachabilityFlags flags;
+ 	SCNetworkReachabilityFlags flags = self.reachabilityFlags;
 	
-	if (SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) 
+	if (flags)
     {
 		return ((flags & kSCNetworkReachabilityFlagsConnectionRequired) &&
 				(flags & (kSCNetworkReachabilityFlagsConnectionOnTraffic | kSCNetworkReachabilityFlagsConnectionOnDemand)));
@@ -426,9 +426,9 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 // Is user intervention required?
 -(BOOL)isInterventionRequired
 {
-    SCNetworkReachabilityFlags flags;
+    SCNetworkReachabilityFlags flags = self.reachabilityFlags;
 	
-	if (SCNetworkReachabilityGetFlags(reachabilityRef, &flags)) 
+	if (flags) 
     {
 		return ((flags & kSCNetworkReachabilityFlagsConnectionRequired) &&
 				(flags & kSCNetworkReachabilityFlagsInterventionRequired));


### PR DESCRIPTION
Previously, many methods made a direct call to `SCNetworkReachabilityGetFlags(reachabilityRef, &flags)` to get the flags. Since we already have a method that does this, we can "program to an interface" and have all flag queries go through `-reachabilityFlags` to gain readability (IMO) and more importantly the ability of subclasses overriding `-reachabilityFlags` for automated testing purposes.

Note that I did this in the github file editor to see if there's any interest. If you like the general idea, let me know and I'll do more extensive testing.

If you _really_ like the idea, it would be extra-cool to have Reachability have flag manipulation built into reachability instances, or perhaps provide an official category extension to enable it.

Is my use case clear?
