### PR TITLE
incorrect sample method call

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In addition, it asks the `Reachability` object to consider the WWAN (3G/EDGE/CDM
 	[[NSNotificationCenter defaultCenter] addObserver:self 
 											 selector:@selector(reachabilityChanged:) 
 												 name:kReachabilityChangedNotification 
-											   object:nil];
+											   object:reach];
 											
 	[reach startNotifier];
 


### PR DESCRIPTION
The comment above states that the reachability that caused the notification should be passed in the object parameter, but the method call on the next line just passes in nil.
