### PR TITLE
Add Xcode static library project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ build/
 *.mode2v3
 
 xcuserdata
+xcshareddata

--- a/Reachability.xcodeproj/project.pbxproj
+++ b/Reachability.xcodeproj/project.pbxproj
@@ -1,0 +1,255 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9450FE19195B26E0005F4833 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9450FE18195B26E0005F4833 /* Foundation.framework */; };
+		9450FE3F195B2757005F4833 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9450FE3E195B2757005F4833 /* SystemConfiguration.framework */; };
+		9495A6C8195B27F900B799B4 /* Reachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 9495A6C7195B27F900B799B4 /* Reachability.m */; };
+		9495A6C9195B280400B799B4 /* Reachability.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9495A6C6195B27F900B799B4 /* Reachability.h */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		9450FE13195B26E0005F4833 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				9495A6C9195B280400B799B4 /* Reachability.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		9450FE15195B26E0005F4833 /* libReachability.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReachability.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		9450FE18195B26E0005F4833 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		9450FE3E195B2757005F4833 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		9495A6C6195B27F900B799B4 /* Reachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Reachability.h; sourceTree = SOURCE_ROOT; };
+		9495A6C7195B27F900B799B4 /* Reachability.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Reachability.m; sourceTree = SOURCE_ROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9450FE12195B26E0005F4833 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9450FE3F195B2757005F4833 /* SystemConfiguration.framework in Frameworks */,
+				9450FE19195B26E0005F4833 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9450FE0C195B26E0005F4833 = {
+			isa = PBXGroup;
+			children = (
+				9450FE1A195B26E0005F4833 /* Reachability */,
+				9450FE17195B26E0005F4833 /* Frameworks */,
+				9450FE16195B26E0005F4833 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9450FE16195B26E0005F4833 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9450FE15195B26E0005F4833 /* libReachability.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9450FE17195B26E0005F4833 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9450FE3E195B2757005F4833 /* SystemConfiguration.framework */,
+				9450FE18195B26E0005F4833 /* Foundation.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		9450FE1A195B26E0005F4833 /* Reachability */ = {
+			isa = PBXGroup;
+			children = (
+				9495A6C6195B27F900B799B4 /* Reachability.h */,
+				9495A6C7195B27F900B799B4 /* Reachability.m */,
+			);
+			path = Reachability;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9450FE14195B26E0005F4833 /* Reachability */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9450FE38195B26E0005F4833 /* Build configuration list for PBXNativeTarget "Reachability" */;
+			buildPhases = (
+				9450FE11195B26E0005F4833 /* Sources */,
+				9450FE12195B26E0005F4833 /* Frameworks */,
+				9450FE13195B26E0005F4833 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Reachability;
+			productName = Reachability;
+			productReference = 9450FE15195B26E0005F4833 /* libReachability.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9450FE0D195B26E0005F4833 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0510;
+				ORGANIZATIONNAME = "___FULLUSERNAME___";
+			};
+			buildConfigurationList = 9450FE10195B26E0005F4833 /* Build configuration list for PBXProject "Reachability" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 9450FE0C195B26E0005F4833;
+			productRefGroup = 9450FE16195B26E0005F4833 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9450FE14195B26E0005F4833 /* Reachability */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9450FE11195B26E0005F4833 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9495A6C8195B27F900B799B4 /* Reachability.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		9450FE36195B26E0005F4833 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		9450FE37195B26E0005F4833 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		9450FE39195B26E0005F4833 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DSTROOT = /tmp/Reachability.dst;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		9450FE3A195B26E0005F4833 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DSTROOT = /tmp/Reachability.dst;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9450FE10195B26E0005F4833 /* Build configuration list for PBXProject "Reachability" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9450FE36195B26E0005F4833 /* Debug */,
+				9450FE37195B26E0005F4833 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9450FE38195B26E0005F4833 /* Build configuration list for PBXNativeTarget "Reachability" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9450FE39195B26E0005F4833 /* Debug */,
+				9450FE3A195B26E0005F4833 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 9450FE0D195B26E0005F4833 /* Project object */;
+}

--- a/Reachability.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Reachability.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Reachability.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
I needed to use your project but wanted to include it into an Xcode workspace, so I needed to compile it as a static library. This pull request adds a project file that compiles `Reachability.m` and `Reachability.h` into a 'Reachability' static library.

To use it, add the project to a workspace and add the library to the project. `Reachability.h` can then be included in any project file as `#include "Reachability/Reachability.h"`.

Thanks for the code!
