### PR TITLE
support generating frameworks

### DIFF
--- a/Reachability.h
+++ b/Reachability.h
@@ -28,13 +28,6 @@
 #import <Foundation/Foundation.h>
 #import <SystemConfiguration/SystemConfiguration.h>
 
-#import <sys/socket.h>
-#import <netinet/in.h>
-#import <netinet6/in6.h>
-#import <arpa/inet.h>
-#import <ifaddrs.h>
-#import <netdb.h>
-
 /**
  * Does ARC support GCD objects?
  * It does if the minimum deployment target is iOS 6+ or Mac OS X 8+

--- a/Reachability.m
+++ b/Reachability.m
@@ -27,6 +27,13 @@
 
 #import "Reachability.h"
 
+#import <sys/socket.h>
+#import <netinet/in.h>
+#import <netinet6/in6.h>
+#import <arpa/inet.h>
+#import <ifaddrs.h>
+#import <netdb.h>
+
 
 NSString *const kReachabilityChangedNotification = @"kReachabilityChangedNotification";
 


### PR DESCRIPTION
For a full description of what's happening: https://github.com/AFNetworking/AFNetworking/issues/2205

Basically you cannot build Reachability as a framework ( which CocoaPods will be doing on the next + 1 major release. )  with .h files referencing things outside of the module. Moving them to the .m fixes this like it does in AFNetworking.
