### PR TITLE
Using ARC to managed dispatch objects in a Cocoapod requires suitable deployment targets to be specified

### DIFF
--- a/Reachability.podspec
+++ b/Reachability.podspec
@@ -23,4 +23,5 @@ Pod::Spec.new do |s|
   s.framework    = 'SystemConfiguration'
   s.ios.deployment_target = "6.0"  #required when you drop non-arc support
   s.osx.deployment_target = "10.8" #required when you drop non-arc support
+  s.requires_arc = true
 end


### PR DESCRIPTION
Without this we get an error for @property (strong) dispatch_queue_t reachabilitySerialQueue

http://guides.cocoapods.org/syntax/podspec.html#deployment_target
