### PR TITLE
Fixed dispatch queue usage if OS_OBJECT_USE_OBJC is deactivated.

### DIFF
--- a/Reachability.h
+++ b/Reachability.h
@@ -49,16 +49,18 @@ typedef NS_ENUM(NSInteger, NetworkStatus) {
 
 @class Reachability;
 
-typedef void (^NetworkReachable)(Reachability * reachability);
-typedef void (^NetworkUnreachable)(Reachability * reachability);
+typedef void (^NetworkReachable)(Reachability *reachability);
+typedef void (^NetworkUnreachable)(Reachability *reachability);
+typedef void (^NetworkReachabilityChanged)(Reachability *reachability, SCNetworkReachabilityFlags flags);
 
 
 @interface Reachability : NSObject
 
-@property (nonatomic, copy) NetworkReachable    reachableBlock;
-@property (nonatomic, copy) NetworkUnreachable  unreachableBlock;
+@property (nonatomic, copy) NetworkReachable            reachableBlock;
+@property (nonatomic, copy) NetworkUnreachable          unreachableBlock;
+@property (nonatomic, copy) NetworkReachabilityChanged  reachabilityChangedBlock;
 
-@property (nonatomic, assign) BOOL reachableOnWWAN;
+@property (nonatomic, assign) BOOL                      reachableOnWWAN;
 
 
 +(instancetype)reachabilityWithHostname:(NSString*)hostname;

--- a/Reachability.h
+++ b/Reachability.h
@@ -60,6 +60,12 @@ typedef void (^NetworkReachabilityChanged)(Reachability *reachability, SCNetwork
 @property (nonatomic, copy) NetworkUnreachable          unreachableBlock;
 @property (nonatomic, copy) NetworkReachabilityChanged  reachabilityChangedBlock;
 
+#if !OS_OBJECT_USE_OBJC
+@property (nonatomic, assign) dispatch_queue_t          reachabilitySerialQueue;
+#else
+@property (nonatomic, strong) dispatch_queue_t          reachabilitySerialQueue;
+#endif
+
 @property (nonatomic, assign) BOOL                      reachableOnWWAN;
 
 

--- a/Reachability.m
+++ b/Reachability.m
@@ -94,6 +94,7 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 @synthesize reachabilityObject = _reachabilityObject;
 @synthesize reachableBlock = _reachableBlock;
 @synthesize unreachableBlock = _unreachableBlock;
+@synthesize reachabilityChangedBlock = _reachabilityChangedBlock;
 @synthesize reachableOnWWAN = _reachableOnWWAN;
 
 #pragma mark - Class Constructor Methods
@@ -181,8 +182,9 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
         self.reachabilityRef = nil;
     }
 
-	self.reachableBlock          = nil;
-	self.unreachableBlock        = nil;
+    self.reachableBlock             = nil;
+    self.unreachableBlock           = nil;
+    self.reachabilityChangedBlock   = nil;
 #if !OS_OBJECT_USE_OBJC
 	dispatch_release(_reachabilitySerialQueue);
 	_reachabilitySerialQueue = nil;
@@ -450,6 +452,11 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
 -(void)reachabilityChanged:(SCNetworkReachabilityFlags)flags
 {
+    if(self.reachabilityChangedBlock)
+    {
+        self.reachabilityChangedBlock(self, flags);
+    }
+    
     if([self isReachableWithFlags:flags])
     {
         if(self.reachableBlock)

--- a/Reachability.m
+++ b/Reachability.m
@@ -374,11 +374,11 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 -(BOOL)connectionRequired
 {
     SCNetworkReachabilityFlags flags;
-	
-	if(SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
+    
+    if(SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
     {
-		return (flags & kSCNetworkReachabilityFlagsConnectionRequired);
-	}
+        return (flags & kSCNetworkReachabilityFlagsConnectionRequired);
+    }
     
     return NO;
 }
@@ -386,29 +386,29 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 // Dynamic, on demand connection?
 -(BOOL)isConnectionOnDemand
 {
-	SCNetworkReachabilityFlags flags;
-	
-	if (SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
+    SCNetworkReachabilityFlags flags;
+    
+    if (SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
     {
-		return ((flags & kSCNetworkReachabilityFlagsConnectionRequired) &&
-				(flags & (kSCNetworkReachabilityFlagsConnectionOnTraffic | kSCNetworkReachabilityFlagsConnectionOnDemand)));
-	}
-	
-	return NO;
+        return ((flags & kSCNetworkReachabilityFlagsConnectionRequired) &&
+                (flags & (kSCNetworkReachabilityFlagsConnectionOnTraffic | kSCNetworkReachabilityFlagsConnectionOnDemand)));
+    }
+    
+    return NO;
 }
 
 // Is user intervention required?
 -(BOOL)isInterventionRequired
 {
     SCNetworkReachabilityFlags flags;
-	
-	if (SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
+    
+    if (SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags))
     {
-		return ((flags & kSCNetworkReachabilityFlagsConnectionRequired) &&
-				(flags & kSCNetworkReachabilityFlagsInterventionRequired));
-	}
-	
-	return NO;
+        return ((flags & kSCNetworkReachabilityFlagsConnectionRequired) &&
+                (flags & kSCNetworkReachabilityFlagsInterventionRequired));
+    }
+    
+    return NO;
 }
 
 
@@ -443,19 +443,19 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
 -(NSString*)currentReachabilityString
 {
-	NetworkStatus temp = [self currentReachabilityStatus];
-	
-	if(temp == ReachableViaWWAN)
-	{
+    NetworkStatus temp = [self currentReachabilityStatus];
+    
+    if(temp == ReachableViaWWAN)
+    {
         // Updated for the fact that we have CDMA phones now!
-		return NSLocalizedString(@"Cellular", @"");
-	}
-	if (temp == ReachableViaWiFi) 
-	{
-		return NSLocalizedString(@"WiFi", @"");
-	}
-	
-	return NSLocalizedString(@"No Connection", @"");
+        return NSLocalizedString(@"Cellular", @"");
+    }
+    if (temp == ReachableViaWiFi)
+    {
+        return NSLocalizedString(@"WiFi", @"");
+    }
+    
+    return NSLocalizedString(@"No Connection", @"");
 }
 
 -(NSString*)currentReachabilityFlags

--- a/Reachability.m
+++ b/Reachability.m
@@ -41,7 +41,11 @@ NSString *const kReachabilityChangedNotification = @"kReachabilityChangedNotific
 @interface Reachability ()
 
 @property (nonatomic, assign) SCNetworkReachabilityRef  reachabilityRef;
+#if !OS_OBJECT_USE_OBJC
+@property (nonatomic, assign) dispatch_queue_t          reachabilitySerialQueue;
+#else
 @property (nonatomic, strong) dispatch_queue_t          reachabilitySerialQueue;
+#endif
 @property (nonatomic, strong) id                        reachabilityObject;
 
 -(void)reachabilityChanged:(SCNetworkReachabilityFlags)flags;
@@ -179,7 +183,12 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
 	self.reachableBlock          = nil;
 	self.unreachableBlock        = nil;
-    self.reachabilitySerialQueue = nil;
+#if !OS_OBJECT_USE_OBJC
+	dispatch_release(_reachabilitySerialQueue);
+	_reachabilitySerialQueue = nil;
+#else
+	self.reachabilitySerialQueue = nil;
+#endif
 }
 
 #pragma mark - Notifier Methods

--- a/Reachability.m
+++ b/Reachability.m
@@ -85,6 +85,12 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
 
 @implementation Reachability
+@synthesize reachabilityRef = _reachabilityRef;
+@synthesize reachabilitySerialQueue = _reachabilitySerialQueue;
+@synthesize reachabilityObject = _reachabilityObject;
+@synthesize reachableBlock = _reachableBlock;
+@synthesize unreachableBlock = _unreachableBlock;
+@synthesize reachableOnWWAN = _reachableOnWWAN;
 
 #pragma mark - Class Constructor Methods
 


### PR DESCRIPTION
I have legacy code that must run on iOS 4.3 but dispatch objects are not bridged with Objective-C on this system. Thus, i need to define OS_OBJECT_USE_OBJC to zero to deactivate bridging between dispatch objects and obj-c.
So this patch fix serial queue stuff when bridging is deactivated. I also fixed properties synthesis when compiling with [-Wobjc-missing-property-synthesis option (I love to compile with -Wall -Wextra options 😝).
Finally, I added API for custom management of the serial queue and the reachability changed event.

Regards.