### PR TITLE
Potential Leaks in Xcode 7 when using static Analyzer

### DIFF
--- a/Reachability.m
+++ b/Reachability.m
@@ -95,21 +95,10 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 
 +(instancetype)reachabilityWithHostname:(NSString*)hostname
 {
-    SCNetworkReachabilityRef ref = SCNetworkReachabilityCreateWithName(NULL, [hostname UTF8String]);
-    if (ref) 
-    {
-        id reachability = [[self alloc] initWithReachabilityRef:ref];
-
-        return reachability;
-    }
+    //Potential leak of an object stored into ref
     
-    return nil;
-}
-
-+(instancetype)reachabilityWithAddress:(void *)hostAddress
-{
-    SCNetworkReachabilityRef ref = SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, (const struct sockaddr*)hostAddress);
-    if (ref) 
+    SCNetworkReachabilityRef ref = CFAutorelease(SCNetworkReachabilityCreateWithName(NULL, [hostname UTF8String]));
+    if (ref)
     {
         id reachability = [[self alloc] initWithReachabilityRef:ref];
         
@@ -118,6 +107,22 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
     
     return nil;
 }
+
++(instancetype)reachabilityWithAddress:(void *)hostAddress
+{
+    //Potential leak of an object stored into ref
+    
+    SCNetworkReachabilityRef ref = CFAutorelease(SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, (const struct sockaddr*)hostAddress));
+    if (ref)
+    {
+        id reachability = [[self alloc] initWithReachabilityRef:ref];
+        
+        return reachability;
+    }
+    
+    return nil;
+}
+
 
 +(instancetype)reachabilityForInternetConnection
 {


### PR DESCRIPTION
We are getting Potential Leaks in Reachability.m 

Leaks showing in methods "reachabilityWithHostname:" and "reachabilityWithAddress:".

Line numbers 101 and 114 in Reachability.m, "Potential leak of an object stored into 'ref'"

Attached the screenshot of the issue.

<img width="893" alt="screen shot 2015-09-25 at 12 20 07 am" src="https://cloud.githubusercontent.com/assets/7402115/10160758/2932f2ba-66bd-11e5-8949-14b4f4543651.png">