### PR TITLE
Turning on App extension API Only for iOS and OSX framework targets

### DIFF
--- a/Framework/Framework.xcodeproj/project.pbxproj
+++ b/Framework/Framework.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 		86E2EFE81B4EE3C9002D66BB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -309,6 +310,7 @@
 		86E2EFE91B4EE3C9002D66BB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -326,6 +328,7 @@
 		86E2F0061B4EE3DE002D66BB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -351,6 +354,7 @@
 		86E2F0071B4EE3DE002D66BB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
This setting needs to be enabled to silence warnings when using this Framework in an app extension.

Details are on this apple doc: https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html under "Using an Embedded Framework to Share Code"

Toggling this on basically stops us from using any APIs that are not allowed in app extensions such as UIApplication.sharedApplication() - which we're not.