### PR TITLE
Add SwiftPM and Github actions support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,40 @@
+name: "Reachability CI"
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  Pods:
+    name: Cocoapods Lint (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable
+
+      - name: Run pod lib lint
+        run: pod lib lint --fail-fast
+          
+  SwiftPM:
+    name: SwiftPM (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable 
+
+      - name: Build
+        run: swift build

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ build/
 *.mode2v3
 
 xcuserdata
+
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "Reachability",
+    platforms: [
+        .iOS(.v9),
+        .macOS(.v10_10),
+        .tvOS(.v9),
+    ],
+    products: [
+        .library(
+            name: "Reachability",
+            targets: ["Reachability"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "Reachability"),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Reference Status](https://www.versioneye.com/objective-c/reachability/reference_badge.svg?style=flat)](https://www.versioneye.com/objective-c/reachability/references)
+[![build-status](https://github.com/tonymillion/Reachability/actions/workflows/CI.yml/badge.svg)](https://github.com/tonymillion/Reachability/actions)
 
 # **WARNING** there have been reports of apps being rejected when Reachability is used in a framework. The only solution to this so far is to rename the class.
 

--- a/Reachability.podspec
+++ b/Reachability.podspec
@@ -13,7 +13,7 @@ EOF
 
 Pod::Spec.new do |s|
   s.name         = 'Reachability'
-  s.version      = '3.2'
+  s.version      = '3.3'
   s.summary      = 'ARC and GCD Compatible Reachability Class for iOS and OS X. Drop in replacement for Apple Reachability.'
 
   s.homepage     = 'https://github.com/tonymillion/Reachability'

--- a/Sources/Reachability/Reachability.m
+++ b/Sources/Reachability/Reachability.m
@@ -1,0 +1,1 @@
+../../Reachability.m

--- a/Sources/Reachability/include/Reachability.h
+++ b/Sources/Reachability/include/Reachability.h
@@ -1,0 +1,1 @@
+../../../Reachability.h


### PR DESCRIPTION
* Add Github actions for continuous-integration. Actions will take into affect immediately as shown on my fork: https://github.com/master-nevi/Reachability/actions
* Used symbolic links to make the directory structure more SwiftPM friendly. While a directory restructure update would have worked also, it felt like there would be less disturbance to a mature and stable library if I left that alone, especially with the 3 test apps. I'm totally happy to re-work the directory structure if that was necessary.
* Bump version to `3.3` 
* Update README badge

closes #176
cc @tonymillion 