### PR TITLE
Bump minimum iOS version

### DIFF
--- a/Framework/Framework.xcodeproj/project.pbxproj
+++ b/Framework/Framework.xcodeproj/project.pbxproj
@@ -299,7 +299,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_MODULE_NAME = Reachability;
 				PRODUCT_NAME = Reachability;
@@ -317,7 +317,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_MODULE_NAME = Reachability;
 				PRODUCT_NAME = Reachability;

--- a/Reachability.podspec
+++ b/Reachability.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.swift_version = "4.1"
-  s.ios.deployment_target = "6.0"
+  s.ios.deployment_target = "11.0"
   s.osx.deployment_target = "10.8"
   s.tvos.deployment_target = "9.0"
 end

--- a/iOSReachabilityTestARC/iOSReachabilityTestARC.xcodeproj/project.pbxproj
+++ b/iOSReachabilityTestARC/iOSReachabilityTestARC.xcodeproj/project.pbxproj
@@ -272,7 +272,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "iOSReachabilityTestARC/iOSReachabilityTestARC-Prefix.pch";
 				INFOPLIST_FILE = "iOSReachabilityTestARC/iOSReachabilityTestARC-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -284,7 +284,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "iOSReachabilityTestARC/iOSReachabilityTestARC-Prefix.pch";
 				INFOPLIST_FILE = "iOSReachabilityTestARC/iOSReachabilityTestARC-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};


### PR DESCRIPTION

Xcode 13 dropped support for iOS 10 and below.
This solves some compiling issues when building Apps with Xcode 13.