### PR TITLE
Add privacy file: Update podspec

### DIFF
--- a/Reachability.podspec
+++ b/Reachability.podspec
@@ -24,6 +24,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => 'https://github.com/tonymillion/Reachability.git', :tag => "v#{s.version}" }
   s.source_files = 'Reachability.{h,m}'
+  s.resource_bundles = {"Reachability_Privacy" => ["Framework/PrivacyInfo.xcprivacy"]}
   s.framework    = 'SystemConfiguration'
 
   s.requires_arc = true


### PR DESCRIPTION
Issue: https://github.com/tonymillion/Reachability/issues/192

It seems that we already have the PrivacyInfo.xcprivacy file. 
However, it has not been added to the podspec, resulting in the absence of the PrivacyInfo.xcprivacy file when installing the library via CocoaPods.