### PR TITLE
Remove direct import of netinet6/in6.h to fix Xcode 26.4 build error

### DIFF
--- a/Reachability.m
+++ b/Reachability.m
@@ -29,7 +29,6 @@
 
 #import <sys/socket.h>
 #import <netinet/in.h>
-#import <netinet6/in6.h>
 #import <arpa/inet.h>
 #import <ifaddrs.h>
 #import <netdb.h>


### PR DESCRIPTION
## Summary

- Remove the redundant `#import <netinet6/in6.h>` from `Reachability.m` to fix a build failure with Xcode 26.4 beta 2.

## Background

In the macOS 26.4 SDK (shipped with Xcode 26.4 beta 2), Apple changed the module map declaration for `netinet6/in6.h` from `exclude header` to `private textual header` in `netinet.modulemap`:

**Before (Xcode 26.3 and earlier):**
```
exclude header "netinet6/in6.h"
```

**After (Xcode 26.4 beta 2):**
```
private textual header "netinet6/in6.h"
```

This causes two compilation errors when `netinet6/in6.h` is directly imported:

1. `error: use of private header from outside its module: 'netinet6/in6.h' [-Wprivate-header]`
2. `#error "do not include netinet6/in6.h directly, include netinet/in.h. see RFC2553"`

The direct import was always redundant — `netinet6/in6.h` is an internal header of `netinet/in.h`, which is already imported on the line above. The header itself states it should not be included directly (per RFC 2553).

## Test plan

- [x] Verified build fails **without** this change on Xcode 26.4 beta 2
- [x] Verified build succeeds **with** this change on Xcode 26.4 beta 2